### PR TITLE
Update install-arm64-devtools.sh

### DIFF
--- a/install-arm64-devtools.sh
+++ b/install-arm64-devtools.sh
@@ -5,4 +5,4 @@ sudo apt-get install -y golang
 
 # Docker dependencies
 #   ATTENTION: this creates a new /boot/initrd.img, takes a long time
-sudo apt-get install -y btrfs-tools libsqlite3-dev libdevmapper-dev
+sudo apt-get install -y btrfs-tools libsqlite3-dev libdevmapper-dev gcc


### PR DESCRIPTION
Added missing gcc, but anyway, I think, this can be a oneliner with installation of golang.
